### PR TITLE
build: updated dependency usb_device

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  usb_device: ^0.0.7
+  usb_device: ^1.0.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
The old dependency version was not working for me. Now it works. 

More specifically, I want calling `.pairDevice` without any parameters. But this method was not implemented when without parameters on the version 0.0.7.